### PR TITLE
Added missing create_connectivity

### DIFF
--- a/tutorials/03_lagrange_multipliers/tutorial_lagrange_multipliers_interface.ipynb
+++ b/tutorials/03_lagrange_multipliers/tutorial_lagrange_multipliers_interface.ipynb
@@ -238,6 +238,7 @@
    "outputs": [],
    "source": [
     "# Define restrictions\n",
+    "mesh.topology.create_connectivity(mesh.topology.dim, mesh.topology.dim)\n",
     "dofs_V1_Omega1 = dolfinx.fem.locate_dofs_topological(V1, subdomains.dim, cells_Omega1)\n",
     "dofs_V2_Omega2 = dolfinx.fem.locate_dofs_topological(V2, subdomains.dim, cells_Omega2)\n",
     "dofs_M_Gamma = dolfinx.fem.locate_dofs_topological(M, boundaries_and_interfaces.dim, facets_Gamma)\n",


### PR DESCRIPTION
Needed this line to run the interface section of tuto 03 with the latest versions of dolfinx etc. I think it's missing in more places but it's a hassle for me to confirm since I am copy-pasting the jupyter-notebooks to scripts.