### PR TITLE
Change `set_bc` and `set_bc_nest` to allow either restricted or unrestricted `x0`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Francesco Ballarin <francesco.ballarin@unicatt.it>
 with contributions from
 
 Paul T. Kühner
+Mehdi Slimani <mehdi.slimani.elmaddarsi@gmail.com>

--- a/multiphenicsx/fem/petsc.py
+++ b/multiphenicsx/fem/petsc.py
@@ -805,7 +805,10 @@ def assemble_vector_block(  # type: ignore[no-any-unimported]
     bcs
         Optional list of boundary conditions.
     x0
-        Optional vector storing the solution.
+        Optional PETSc vector storing the solution.
+        Typically the current nonlinear solution in an incremental problem is provided as `x0`.
+        See the documentation of :func:`multiphenicsx.fem.petsc.apply_lifting` for more details about
+        how `restriction_x0` is used in combination with `x0`.
     alpha
         Optional scaling factor for boundary conditions application.
     constants_L, constants_a
@@ -858,7 +861,10 @@ def _(  # type: ignore[no-any-unimported]
     bcs
         Optional list of boundary conditions.
     x0
-        Optional vector storing the solution.
+        Optional PETSc vector storing the solution.
+        Typically the current nonlinear solution in an incremental problem is provided as `x0`.
+        See the documentation of :func:`multiphenicsx.fem.petsc.apply_lifting` for more details about
+        how `restriction_x0` is used in combination with `x0`.
     alpha
         Optional scaling factor for boundary conditions application.
     constants_L, constants_a


### PR DESCRIPTION
I jumped a bit the gun with respect to what you proposed in [the forum post](https://fenicsproject.discourse.group/t/issue-with-multiphenicsx-fem-petsc-set-bc-x0-argument/16089/8) and changed `set_bc` and `set_bc_nest` to expect an unrestricted `x0`. Have a look at how I documented `set_bc` if you can (`sphinx` style maths). I will open the PR we discussed with documentation of the same style later today.

The `multiphenicsx` variants of `apply_lifting` and `set_bc` are not used in the tutorials with their `x0` argument, that is only done in the tests. I modified the tests and checked that they pass in this branch.