### PR TITLE
Replace `std::map` by `std::unordered_map`

### DIFF
--- a/multiphenicsx/cpp/multiphenicsx/fem/DofMapRestriction.cpp
+++ b/multiphenicsx/cpp/multiphenicsx/fem/DofMapRestriction.cpp
@@ -50,8 +50,8 @@ DofMapRestriction::DofMapRestriction(
 //-----------------------------------------------------------------------------
 void DofMapRestriction::_compute_cell_dofs(std::shared_ptr<const DofMap> dofmap)
 {
-  // Fill in cell dofs first into a temporary std::map
-  std::map<int, std::vector<std::int32_t>> restricted_cell_dofs;
+  // Fill in cell dofs first into a temporary std::unordered_map
+  std::unordered_map<int, std::vector<std::int32_t>> restricted_cell_dofs;
   std::size_t restricted_cell_dofs_total_size = 0;
   auto unrestricted_cell_dofs = dofmap->map();
   const int num_cells = unrestricted_cell_dofs.extent(0);
@@ -82,8 +82,8 @@ void DofMapRestriction::_compute_cell_dofs(std::shared_ptr<const DofMap> dofmap)
     }
   }
 
-  // Flatten std::map into the std::vector dof_array, and store start/end
-  // indices associated to each cell in cell_bounds
+  // Flatten std::unordered_map into the std::vector dof_array, and store
+  // start/end indices associated to each cell in cell_bounds
   _dof_array.reserve(restricted_cell_dofs_total_size);
   _cell_bounds.reserve(num_cells + 1);
   std::size_t current_cell_bound = 0;

--- a/multiphenicsx/cpp/multiphenicsx/fem/DofMapRestriction.h
+++ b/multiphenicsx/cpp/multiphenicsx/fem/DofMapRestriction.h
@@ -8,8 +8,8 @@
 
 #include <dolfinx/common/IndexMap.h>
 #include <dolfinx/fem/DofMap.h>
-#include <map>
 #include <memory>
+#include <unordered_map>
 
 namespace multiphenicsx
 {
@@ -59,13 +59,15 @@ public:
   std::shared_ptr<const dolfinx::fem::DofMap> dofmap() const { return _dofmap; }
 
   /// Return map from unrestricted dofs to restricted dofs
-  const std::map<std::int32_t, std::int32_t>& unrestricted_to_restricted() const
+  const std::unordered_map<std::int32_t, std::int32_t>&
+  unrestricted_to_restricted() const
   {
     return _unrestricted_to_restricted;
   }
 
   /// Map from restricted dofs to unrestricted dofs
-  const std::map<std::int32_t, std::int32_t>& restricted_to_unrestricted() const
+  const std::unordered_map<std::int32_t, std::int32_t>&
+  restricted_to_unrestricted() const
   {
     return _restricted_to_unrestricted;
   }
@@ -94,10 +96,10 @@ private:
   std::shared_ptr<const dolfinx::fem::DofMap> _dofmap;
 
   // Map from unrestricted dofs to restricted dofs
-  std::map<std::int32_t, std::int32_t> _unrestricted_to_restricted;
+  std::unordered_map<std::int32_t, std::int32_t> _unrestricted_to_restricted;
 
   // Map from restricted dofs to unrestricted dofs
-  std::map<std::int32_t, std::int32_t> _restricted_to_unrestricted;
+  std::unordered_map<std::int32_t, std::int32_t> _restricted_to_unrestricted;
 
   // Cell-local-to-dof map after restriction has been carried out
   std::vector<std::int32_t> _dof_array;

--- a/multiphenicsx/cpp/multiphenicsx/la/petsc.cpp
+++ b/multiphenicsx/cpp/multiphenicsx/la/petsc.cpp
@@ -138,7 +138,7 @@ MatSubMatrixWrapper::MatSubMatrixWrapper(Mat A, std::array<IS, 2> index_sets)
 MatSubMatrixWrapper::MatSubMatrixWrapper(
     Mat A, std::array<IS, 2> unrestricted_index_sets,
     std::array<IS, 2> restricted_index_sets,
-    std::array<std::map<std::int32_t, std::int32_t>, 2>
+    std::array<std::unordered_map<std::int32_t, std::int32_t>, 2>
         unrestricted_to_restricted,
     std::array<int, 2> unrestricted_to_restricted_bs)
     : MatSubMatrixWrapper(A, restricted_index_sets)
@@ -348,7 +348,8 @@ VecSubVectorReadWrapper::VecSubVectorReadWrapper(Vec x, IS index_set,
 //-----------------------------------------------------------------------------
 VecSubVectorReadWrapper::VecSubVectorReadWrapper(
     Vec x, IS unrestricted_index_set, IS restricted_index_set,
-    const std::map<std::int32_t, std::int32_t>& unrestricted_to_restricted,
+    const std::unordered_map<std::int32_t, std::int32_t>&
+        unrestricted_to_restricted,
     int unrestricted_to_restricted_bs, bool ghosted)
     : _ghosted(ghosted)
 {
@@ -446,7 +447,8 @@ VecSubVectorWrapper::VecSubVectorWrapper(Vec x, IS index_set, bool ghosted)
 //-----------------------------------------------------------------------------
 VecSubVectorWrapper::VecSubVectorWrapper(
     Vec x, IS unrestricted_index_set, IS restricted_index_set,
-    const std::map<std::int32_t, std::int32_t>& unrestricted_to_restricted,
+    const std::unordered_map<std::int32_t, std::int32_t>&
+        unrestricted_to_restricted,
     int unrestricted_to_restricted_bs, bool ghosted)
     : VecSubVectorReadWrapper(x, unrestricted_index_set, restricted_index_set,
                               unrestricted_to_restricted,

--- a/multiphenicsx/cpp/multiphenicsx/la/petsc.h
+++ b/multiphenicsx/cpp/multiphenicsx/la/petsc.h
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <dolfinx/common/IndexMap.h>
-#include <map>
 #include <petscmat.h>
 #include <petscvec.h>
+#include <unordered_map>
 #include <vector>
 
 namespace multiphenicsx::la
@@ -63,11 +63,12 @@ public:
   MatSubMatrixWrapper(Mat A, std::array<IS, 2> index_sets),
 
       /// Constructor (for cases with restriction)
-      MatSubMatrixWrapper(Mat A, std::array<IS, 2> unrestricted_index_sets,
-                          std::array<IS, 2> restricted_index_sets,
-                          std::array<std::map<std::int32_t, std::int32_t>, 2>
-                              unrestricted_to_restricted,
-                          std::array<int, 2> unrestricted_to_restricted_bs);
+      MatSubMatrixWrapper(
+          Mat A, std::array<IS, 2> unrestricted_index_sets,
+          std::array<IS, 2> restricted_index_sets,
+          std::array<std::unordered_map<std::int32_t, std::int32_t>, 2>
+              unrestricted_to_restricted,
+          std::array<int, 2> unrestricted_to_restricted_bs);
 
   /// Destructor
   ~MatSubMatrixWrapper();
@@ -105,12 +106,11 @@ public:
   VecSubVectorReadWrapper(Vec x, IS index_set, bool ghosted = true),
 
       /// Constructor (for cases with restriction)
-      VecSubVectorReadWrapper(Vec x, IS unrestricted_index_set,
-                              IS restricted_index_set,
-                              const std::map<std::int32_t, std::int32_t>&
-                                  unrestricted_to_restricted,
-                              int unrestricted_to_restricted_bs,
-                              bool ghosted = true);
+      VecSubVectorReadWrapper(
+          Vec x, IS unrestricted_index_set, IS restricted_index_set,
+          const std::unordered_map<std::int32_t, std::int32_t>&
+              unrestricted_to_restricted,
+          int unrestricted_to_restricted_bs, bool ghosted = true);
 
   /// Destructor
   ~VecSubVectorReadWrapper();
@@ -146,7 +146,7 @@ public:
       /// Constructor (for cases with restriction)
       VecSubVectorWrapper(Vec x, IS unrestricted_index_set,
                           IS restricted_index_set,
-                          const std::map<std::int32_t, std::int32_t>&
+                          const std::unordered_map<std::int32_t, std::int32_t>&
                               unrestricted_to_restricted,
                           int unrestricted_to_restricted_bs,
                           bool ghosted = true);
@@ -172,7 +172,7 @@ public:
 private:
   Vec _global_vector;
   IS _is;
-  std::map<std::int32_t, std::int32_t> _restricted_to_unrestricted;
+  std::unordered_map<std::int32_t, std::int32_t> _restricted_to_unrestricted;
 };
 
 } // namespace petsc

--- a/multiphenicsx/cpp/multiphenicsx/wrappers/fem.cpp
+++ b/multiphenicsx/cpp/multiphenicsx/wrappers/fem.cpp
@@ -17,10 +17,10 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/array.h>
 #include <nanobind/stl/complex.h>
-#include <nanobind/stl/map.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/vector.h>
 #include <petsc4py/petsc4py.h>
 #include <span>

--- a/multiphenicsx/cpp/multiphenicsx/wrappers/la.cpp
+++ b/multiphenicsx/cpp/multiphenicsx/wrappers/la.cpp
@@ -13,8 +13,8 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/array.h>
 #include <nanobind/stl/complex.h>
-#include <nanobind/stl/map.h>
 #include <nanobind/stl/pair.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/vector.h>
 #include <petsc4py/petsc4py.h>
 #include <petscis.h>
@@ -37,9 +37,10 @@ void la_petsc_module(nb::module_& m)
       m, "MatSubMatrixWrapper")
       .def(nb::init<Mat, std::array<IS, 2>>(), nb::arg("A"),
            nb::arg("index_sets"))
-      .def(nb::init<Mat, std::array<IS, 2>, std::array<IS, 2>,
-                    std::array<std::map<std::int32_t, std::int32_t>, 2>,
-                    std::array<int, 2>>(),
+      .def(nb::init<
+               Mat, std::array<IS, 2>, std::array<IS, 2>,
+               std::array<std::unordered_map<std::int32_t, std::int32_t>, 2>,
+               std::array<int, 2>>(),
            nb::arg("A"), nb::arg("unrestricted_index_sets"),
            nb::arg("restricted_index_sets"),
            nb::arg("unrestricted_to_restricted"),
@@ -57,8 +58,9 @@ void la_petsc_module(nb::module_& m)
       m, "VecSubVectorReadWrapper")
       .def(nb::init<Vec, IS, bool>(), nb::arg("x"), nb::arg("index_set"),
            nb::arg("ghosted") = true)
-      .def(nb::init<Vec, IS, IS, const std::map<std::int32_t, std::int32_t>&,
-                    int, bool>(),
+      .def(nb::init<Vec, IS, IS,
+                    const std::unordered_map<std::int32_t, std::int32_t>&, int,
+                    bool>(),
            nb::arg("x"), nb::arg("unrestricted_index_set"),
            nb::arg("restricted_index_set"),
            nb::arg("unrestricted_to_restricted"),
@@ -78,8 +80,9 @@ void la_petsc_module(nb::module_& m)
       m, "VecSubVectorWrapper")
       .def(nb::init<Vec, IS, bool>(), nb::arg("x"), nb::arg("index_set"),
            nb::arg("ghosted") = true)
-      .def(nb::init<Vec, IS, IS, const std::map<std::int32_t, std::int32_t>&,
-                    int, bool>(),
+      .def(nb::init<Vec, IS, IS,
+                    const std::unordered_map<std::int32_t, std::int32_t>&, int,
+                    bool>(),
            nb::arg("x"), nb::arg("unrestricted_index_set"),
            nb::arg("restricted_index_set"),
            nb::arg("unrestricted_to_restricted"),


### PR DESCRIPTION
I was profiling my application and saw that the `DofMapRestriction` constructor spent a considerable amount of time with `std::map` operations. I switched `_restricted_to_unrestricted` and `_unrestricted_to_restricted` into `std::unordered_map`s to speed-up the constructor. I'll put some numbers here tomorrow.