### PR TITLE
Add possible resolution to `CMake` error and use `dolfinx.get_include`

### DIFF
--- a/multiphenicsx/cpp/CMakeLists.txt
+++ b/multiphenicsx/cpp/CMakeLists.txt
@@ -41,9 +41,7 @@ endif()
 
 # Check for DOLFINx python wrappers
 execute_process(
-  COMMAND
-    ${Python_EXECUTABLE} -c
-    "import os, sys, dolfinx; print(os.path.join(os.path.dirname(dolfinx.__file__), 'wrappers'))"
+  COMMAND ${Python_EXECUTABLE} -c "import dolfinx; print(dolfinx.get_include())"
   OUTPUT_VARIABLE DOLFINX_PY_WRAPPERS_DIR
   RESULT_VARIABLE DOLFINX_PY_WRAPPERS_COMMAND_RESULT
   ERROR_VARIABLE DOLFINX_PY_WRAPPERS_COMMAND_ERROR

--- a/multiphenicsx/cpp/CMakeLists.txt
+++ b/multiphenicsx/cpp/CMakeLists.txt
@@ -30,7 +30,10 @@ if(NOT NANOBIND_CMAKE_DIR_COMMAND_RESULT)
   find_package(nanobind CONFIG REQUIRED)
   message(STATUS "Found nanobind python wrappers at ${NANOBIND_CMAKE_DIR}")
 else()
-  message(FATAL_ERROR "nanobind could not be found.")
+  message(
+    FATAL_ERROR
+      "nanobind could not be found. Possibly caused by running without '--no-build-isolation'."
+  )
 endif()
 
 # Check for DOLFINx C++ backend
@@ -51,7 +54,10 @@ execute_process(
 if(NOT DOLFINX_PY_WRAPPERS_COMMAND_RESULT)
   message(STATUS "Found DOLFINx python wrappers at ${DOLFINX_PY_WRAPPERS_DIR}")
 else()
-  message(FATAL_ERROR "DOLFINx python wrappers could not be found.")
+  message(
+    FATAL_ERROR
+      "DOLFINx python wrappers could not be found. Possibly caused by running without '--no-build-isolation'."
+  )
 endif()
 
 # Check for petsc4py
@@ -67,7 +73,10 @@ execute_process(
 if(NOT PETSC4PY_INCLUDE_COMMAND_RESULT)
   message(STATUS "Found petsc4py include directory at ${PETSC4PY_INCLUDE_DIR}")
 else()
-  message(FATAL_ERROR "petsc4py could not be found.")
+  message(
+    FATAL_ERROR
+      "petsc4py could not be found. Possibly caused by running without '--no-build-isolation'."
+  )
 endif()
 
 # Check for mpi4py
@@ -82,7 +91,10 @@ execute_process(
 if(NOT MPI4PY_INCLUDE_COMMAND_RESULT)
   message(STATUS "Found mpi4py include directory at ${MPI4PY_INCLUDE_DIR}")
 else()
-  message(FATAL_ERROR "mpi4py could not be found.")
+  message(
+    FATAL_ERROR
+      "mpi4py could not be found. Possibly caused by running without '--no-build-isolation'."
+  )
 endif()
 
 # Compile multiphenicsx C++ backend and nanobind wrappers


### PR DESCRIPTION
Faced this while trying to replicate things on my own, thought it could be useful for others. It is not straight forward, why the python context in the terminal is not the same as the one of the `CMake` setup.